### PR TITLE
Allow text to be dragged and dropped

### DIFF
--- a/dataview_tree.livecodescript
+++ b/dataview_tree.livecodescript
@@ -2687,9 +2687,9 @@ To disallow drag reordering set `the viewProp["allow drag reordering"]` property
 Returns: nothing
 */
 on dragStart
+  if word 1 of the target is "field" and not the lockText of the target then pass dragStart
   if the viewProp["allow drag reordering"] of me is false then exit dragStart
   if the mouseControl is empty or the dvRowControl of the mouseControl is empty then exit dragStart
-  if word 1 of the target is "field" and not the lockText of the target then exit dragStart
 
   local tTargetRows, tRow, tNodeId, tNodeA
   local tNodeDescendantsA, tProposedNodeIds, tNodeIds, tRootNodeIds, tDescendantIds


### PR DESCRIPTION
If the target of the dragStart message is an unlocked field then pass the message so that the user can drag and drop the text. This overrides any drag reordering behavior.

Fixes #11 